### PR TITLE
make Wrapper ManyInsertable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Master](https://github.com/appwise-labs/AppwiseCore)
 
+## [0.10.5](https://github.com/appwise-labs/AppwiseCore/releases/tag/0.10.5)
+
+### Bug Fixes
+
+* DB: make `Wrapper` inherit `ManyInsertable`. This means `[Wrapper]`s will be `Insertable`, which matches `AlamofireCoreData` behaviour.
+
 ## [0.10.4](https://github.com/appwise-labs/AppwiseCore/releases/tag/0.10.4)
 
 ### New Features

--- a/Sources/CoreData/Insert/Wrapper.swift
+++ b/Sources/CoreData/Insert/Wrapper.swift
@@ -11,7 +11,7 @@ import Foundation
 import Groot
 
 /// Types that implement this method can insert its properties into a managed object context.
-public protocol Wrapper: Insertable {
+public protocol Wrapper: Insertable, ManyInsertable {
     /// Required for instantiate new instances
     init()
 


### PR DESCRIPTION
This fixes a change in behaviour between AlamofireCoreData and AppwiseCore.

``` swift
// AlamofireCoreData
struct Wrapper: Insertable, ManyInsertable { }
struct Many<Element: ManyInsertable>: Insertable { }

struct LeaderboardPosition: Wrapper { }
Many<LeaderboardPosition> // is `Insertable`

// AppwiseCore
struct Wrapper: Insertable { }
extension Array: Insertable where Element: (Insertable & ManyInsertable) { }

struct LeaderboardPosition: Wrapper { }
Array<LeaderboardPosition> // not `Insertable` because `Wrapper` is not `ManyInsertable`
```
By making `Wrapper` `ManyInsertable`, the behaviour is now consistent.