### PR TITLE
make SingleObjectRepository compatible with OptionalIdentifiable

### DIFF
--- a/Sources/CoreData/Repository/SingleObjectRepository.swift
+++ b/Sources/CoreData/Repository/SingleObjectRepository.swift
@@ -6,7 +6,7 @@
 import CoreData
 
 public protocol SingleObjectRepository {
-	associatedtype ObjectType: NSManagedObject & Identifiable
+	associatedtype ObjectType: NSManagedObject & _Identifiable
 
 	var objectID: Identifier<ObjectType> { get }
 	var context: NSManagedObjectContext { get }


### PR DESCRIPTION
This PR makes `SingleObjectRepository` compatible with `OptionalIdentifiable`.
Instead of requiring `ObjectType` to conform to `Identifiable`, it requires `ObjectType` to conform to `_Identifiable`, which both `Identifiable` and `OptionalIdentifiable` conform to.