### PR TITLE
make SingleObjectRepository compatible with OptionalIdentifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Master](https://github.com/appwise-labs/AppwiseCore)
 
-* Make `SingleObjectRepository` compatible with `OptionalIdentifiable`
+* CoreData: make `SingleObjectRepository` compatible with `OptionalIdentifiable`.
 
 ## [1.4.6](https://github.com/appwise-labs/AppwiseCore/releases/tag/1.4.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Master](https://github.com/appwise-labs/AppwiseCore)
 
+* Make `SingleObjectRepository` compatible with `OptionalIdentifiable`
+
 ## [1.4.6](https://github.com/appwise-labs/AppwiseCore/releases/tag/1.4.6)
 
 ### Bug Fixes

--- a/Sources/CoreData/Repository/SingleObjectRepository.swift
+++ b/Sources/CoreData/Repository/SingleObjectRepository.swift
@@ -7,7 +7,7 @@ import Alamofire
 import CoreData
 
 public protocol SingleObjectRepository {
-	associatedtype ObjectType: NSManagedObject & Identifiable
+	associatedtype ObjectType: NSManagedObject & _Identifiable
 
 	var objectID: Identifier<ObjectType> { get }
 	var context: NSManagedObjectContext { get }


### PR DESCRIPTION
This PR makes `SingleObjectRepository` compatible with `OptionalIdentifiable`.
Instead of requiring `ObjectType` to conform to `Identifiable`, it requires `ObjectType` to conform to `_Identifiable`, which both `Identifiable` and `OptionalIdentifiable` conform to.