### PR TITLE
CD: rewrite how `requestInsert` works, to ensure correct threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 * Fastlane: ensure translations export can handle "empty" targets.
 * Scripts: fix Xcode warnings for build steps without input/output files.
 * Bump dependencies (Sentry to 8).
+* CoreData: ensure `requestInsert` imports objects on the context's thread. Note: because of limitations, we're deprecating `responseInsert`.
 
 ### Internal
 

--- a/Sources/CoreData/Insert/DataRequest.swift
+++ b/Sources/CoreData/Insert/DataRequest.swift
@@ -6,18 +6,11 @@
 import Alamofire
 import CoreData
 
-/// A wrapper which encapsulate all the info of the response of a Request
-public struct ResponseInfo {
-	public let request: URLRequest?
-	public let response: HTTPURLResponse?
-	public let data: Data?
-	public let error: Error?
-}
-
 /// A `ResponseSerializer` that decodes the response data using `JSONSerialization` and then imports
 /// it into Core Data using `Groot`. By default, a request returning `nil` or no data is considered an error.
 /// However, if the request has an `HTTPMethod` or the response has an HTTP status code valid for empty
 /// responses, then an `NSNull` value is returned.
+@available(*, deprecated, message: "Considered unsafe, please use `Client.requestInsert` instead.")
 public final class InsertResponseSerializer<T: Insertable>: ResponseSerializer {
 	public let dataPreprocessor: DataPreprocessor
 	public let emptyResponseCodes: Set<Int>
@@ -123,6 +116,7 @@ public extension DataRequest {
 	/// - parameter handler:           The code to be executed once the request has finished.
 	///
 	/// - returns: the request
+	@available(*, deprecated, message: "Considered unsafe, please use `Client.requestInsert` instead.")
 	@discardableResult
 	func responseInsert<T: Insertable>(
 		of type: T.Type = T.self,


### PR DESCRIPTION
The old `responseInsert` creates a temp. background context,  and modifies it. Problem is that those modifications do **not** happen on the context's thread (using `moc.perform`). 

Unfortunately a `ResponseSerializer` cannot run async code, so we cannot use that anymore. Instead this PR deprecates `responseInsert`, and instead fixes the `requestInsert` which **can** run async code on the correct threads.

## Potential breaking change

With the old code, `didImport` functions would receive the unmodified raw JSON data, even though the actual importing would run on the transformed json (from `jsonTransformer`). If the developer wanted to use the transformed json from within `didImport`, they had to transform it again on their own. This PR also fixes this old wrong behaviour.

It's recommended that:
- anyone with a `didImport` function
- combined with a `jsonTransformer`
- checks that they're **not** expecting the raw JSON instead of the transformed version, or remove any duplicate transformation code