### PR TITLE
Improve `Identifiable`

### DIFF
--- a/AppwiseCore.podspec
+++ b/AppwiseCore.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 		:type => 'MIT',
 		:file => 'LICENSE'
 	}
-	s.ios.deployment_target = '10.0'
+	s.ios.deployment_target = '13.0'
 	s.swift_version = '5.0'
 
 	# files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 * Core: deprecate our `Cancelled` error type in favour of Swift's built-in `CancellationError` type.
 * Core: due to unuse, we're marking `OptionalIdentifiable` as deprecated.
+* Core: renamed our own `Identifiable` protocol to `TaggedIdentifiable`.
 * CoreData: due to incorrectness, we're deprecating `responseInsert` (this is not `responseInsert`, see below).
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 * Core: add `requestVoid` method to network client.
 * Core: default error parser now ignores `.explicitlyCancelled` (for cancelled requests).
 * Core: result "cancellation" now uses Swift's built-in `CancellationError` type if available.
+* Core: `TaggedIdentifiable` protocol now conforms to Swift's own `Identifiable` protocol.
 * XcodeGen: added a template for shared frameworks.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Deprecations
 
 * Core: deprecate our `Cancelled` error type in favour of Swift's built-in `CancellationError` type.
+* Core: due to unuse, we're marking `OptionalIdentifiable` as deprecated.
+* CoreData: due to incorrectness, we're deprecating `responseInsert` (this is not `responseInsert`, see below).
 
 ### Improvements
 
@@ -25,7 +27,7 @@ All notable changes to this project will be documented in this file.
 * Fastlane: ensure translations export can handle "empty" targets.
 * Scripts: fix Xcode warnings for build steps without input/output files.
 * Bump dependencies (Sentry to 8).
-* CoreData: ensure `requestInsert` imports objects on the context's thread. Note: because of limitations, we're deprecating `responseInsert`.
+* CoreData: ensure `requestInsert` imports objects on the context's thread.
 
 ### Internal
 

--- a/Sources/Core/Identity.swift
+++ b/Sources/Core/Identity.swift
@@ -12,16 +12,16 @@ import Foundation
 /// Protocol used to mark a given type as being identifiable, meaning
 /// that it has a type-safe identifier, backed by a raw value, which
 /// defaults to String.
-public protocol _Identifiable {
+public protocol _TaggedIdentifiable {
 	// swiftlint:disable:previous type_name
 
-	// Note: once we remove `OptionalIdentifiable`, unify this protocol with `Identifiable` below.
+	// Note: once we remove `OptionalIdentifiable`, unify this protocol with `TaggedIdentifiable` below.
 
 	/// The backing raw type of this type's identifier.
 	associatedtype RawIdentifier
 
 	/// The object type (hack needed to support subclasses)
-	associatedtype IdentifierObjectType: _Identifiable = Self
+	associatedtype IdentifierObjectType: _TaggedIdentifiable = Self
 
 	// swiftlint:disable type_name
 	/// Shorthand type alias for this type's identifier.
@@ -32,7 +32,7 @@ public protocol _Identifiable {
 /// Protocol used to mark a given type as being identifiable, meaning
 /// that it has a type-safe identifier, backed by a raw value, which
 /// defaults to String.
-public protocol Identifiable: _Identifiable {
+public protocol TaggedIdentifiable: _TaggedIdentifiable {
 	// swiftlint:disable identifier_name
 	/// The ID of this instance.
 	var id: ID { get }
@@ -42,7 +42,7 @@ public protocol Identifiable: _Identifiable {
 /// A type-safe identifier for a given `Value`, backed by a raw value.
 /// When backed by a `Codable` type, `Identifier` also becomes codable,
 /// and will be encoded into a single value according to its raw value.
-public struct Identifier<Value: _Identifiable>: RawRepresentable {
+public struct Identifier<Value: _TaggedIdentifiable>: RawRepresentable {
 	/// The raw value that is backing this identifier.
 	public let rawValue: Value.RawIdentifier
 
@@ -127,8 +127,11 @@ extension Identifier: Codable where Value.RawIdentifier: Codable {
 
 // MARK: - Deprecated
 
+@available(*, deprecated, renamed: "TaggedIdentifiable")
+public typealias Identifiable = TaggedIdentifiable
+
 @available(*, deprecated, message: "Will be removed in next major version")
-public protocol OptionalIdentifiable: _Identifiable {
+public protocol OptionalIdentifiable: _TaggedIdentifiable {
 	// swiftlint:disable identifier_name
 	/// The ID of this instance.
 	var id: ID? { get }

--- a/Sources/Core/Identity.swift
+++ b/Sources/Core/Identity.swift
@@ -15,6 +15,8 @@ import Foundation
 public protocol _Identifiable {
 	// swiftlint:disable:previous type_name
 
+	// Note: once we remove `OptionalIdentifiable`, unify this protocol with `Identifiable` below.
+
 	/// The backing raw type of this type's identifier.
 	associatedtype RawIdentifier
 
@@ -34,16 +36,6 @@ public protocol Identifiable: _Identifiable {
 	// swiftlint:disable identifier_name
 	/// The ID of this instance.
 	var id: ID { get }
-	// swiftlint:enable identifier_name
-}
-
-/// Protocol used to mark a given type as being identifiable, meaning
-/// that it has a type-safe identifier, backed by a raw value, which
-/// defaults to String.
-public protocol OptionalIdentifiable: _Identifiable {
-	// swiftlint:disable identifier_name
-	/// The ID of this instance.
-	var id: ID? { get }
 	// swiftlint:enable identifier_name
 }
 
@@ -131,4 +123,14 @@ extension Identifier: Codable where Value.RawIdentifier: Codable {
 		var container = encoder.singleValueContainer()
 		try container.encode(rawValue)
 	}
+}
+
+// MARK: - Deprecated
+
+@available(*, deprecated, message: "Will be removed in next major version")
+public protocol OptionalIdentifiable: _Identifiable {
+	// swiftlint:disable identifier_name
+	/// The ID of this instance.
+	var id: ID? { get }
+	// swiftlint:enable identifier_name
 }

--- a/Sources/Core/Identity.swift
+++ b/Sources/Core/Identity.swift
@@ -103,7 +103,12 @@ extension Identifier: CustomDebugStringConvertible {
 
 extension Identifier: Equatable where Value.RawIdentifier: Equatable {}
 
-extension Identifier: Hashable where Value.RawIdentifier: Hashable {}
+extension Identifier: Hashable where Value.RawIdentifier: Hashable {
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(String(describing: Value.self))
+		hasher.combine(rawValue)
+	}
+}
 
 extension Identifier: Comparable where Value.RawIdentifier: Comparable {
 	public static func < (lhs: Identifier<Value>, rhs: Identifier<Value>) -> Bool {

--- a/Sources/Core/Identity.swift
+++ b/Sources/Core/Identity.swift
@@ -18,24 +18,29 @@ public protocol _TaggedIdentifiable {
 	// Note: once we remove `OptionalIdentifiable`, unify this protocol with `TaggedIdentifiable` below.
 
 	/// The backing raw type of this type's identifier.
-	associatedtype RawIdentifier
+	associatedtype RawIdentifier: Hashable
 
 	/// The object type (hack needed to support subclasses)
 	associatedtype IdentifierObjectType: _TaggedIdentifiable = Self
 
+	/// Shorthand type alias for this type's identifier.
+	typealias TaggedID = Identifier<IdentifierObjectType>
+
 	// swiftlint:disable type_name
 	/// Shorthand type alias for this type's identifier.
-	typealias ID = Identifier<IdentifierObjectType>
+	///
+	/// - Warning: Prefer `TaggedID` to avoid ambiguity errors.
+	typealias ID = TaggedID
 	// swiftlint:enable type_name
 }
 
 /// Protocol used to mark a given type as being identifiable, meaning
 /// that it has a type-safe identifier, backed by a raw value, which
 /// defaults to String.
-public protocol TaggedIdentifiable: _TaggedIdentifiable {
+public protocol TaggedIdentifiable<RawIdentifier>: _TaggedIdentifiable, Swift.Identifiable {
 	// swiftlint:disable identifier_name
 	/// The ID of this instance.
-	var id: ID { get }
+	var id: TaggedID { get }
 	// swiftlint:enable identifier_name
 }
 
@@ -138,7 +143,6 @@ public typealias Identifiable = TaggedIdentifiable
 @available(*, deprecated, message: "Will be removed in next major version")
 public protocol OptionalIdentifiable: _TaggedIdentifiable {
 	// swiftlint:disable identifier_name
-	/// The ID of this instance.
-	var id: ID? { get }
+	var id: TaggedID? { get }
 	// swiftlint:enable identifier_name
 }

--- a/Sources/CoreData/Repository/SingleObjectRepository.swift
+++ b/Sources/CoreData/Repository/SingleObjectRepository.swift
@@ -6,7 +6,7 @@
 import CoreData
 
 public protocol SingleObjectRepository {
-	associatedtype ObjectType: NSFetchRequestResult, _Identifiable
+	associatedtype ObjectType: NSFetchRequestResult, _TaggedIdentifiable
 
 	var objectID: Identifier<ObjectType> { get }
 	var context: NSManagedObjectContext { get }

--- a/Sources/CoreData/Repository/SingleObjectRepository.swift
+++ b/Sources/CoreData/Repository/SingleObjectRepository.swift
@@ -8,18 +8,18 @@ import CoreData
 public protocol SingleObjectRepository {
 	associatedtype ObjectType: NSFetchRequestResult, _TaggedIdentifiable
 
-	var objectID: Identifier<ObjectType> { get }
+	var objectID: ObjectType.TaggedID { get }
 	var context: NSManagedObjectContext { get }
 	var object: ObjectType? { get }
 
-	init(objectID: Identifier<ObjectType>, context: NSManagedObjectContext)
+	init(objectID: ObjectType.TaggedID, context: NSManagedObjectContext)
 	func refresh(then handler: @escaping (Result<ObjectType, Error>) -> Void)
 }
 
 // MARK: - Default implementations
 
 public extension SingleObjectRepository {
-	init(objectID: Identifier<ObjectType>) {
+	init(objectID: ObjectType.TaggedID) {
 		self.init(objectID: objectID, context: DB.shared.view)
 	}
 


### PR DESCRIPTION
* Marks `OptionalIdentifiable` as deprecated.
* Renames our own `Identifiable` protocol to `TaggedIdentifiable` (to avoid conflict with Swift's protocol)
* `TaggedIdentifiable` protocol now conforms to Swift's own `Identifiable` protocol.

⚠️ bumps minimum iOS to 13.