### PR TITLE
Small script tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 * Bump dependencies (Sentry to 8).
 * CoreData: ensure `requestInsert` imports objects on the context's thread.
 * Sourcery: fix code generation for `Self.ID` properties.
+* SwiftLint: fix warnings from using deprecated rules (because we use `all`).
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecations
 
 * Core: deprecate our `Cancelled` error type in favour of Swift's built-in `CancellationError` type.
+* CoreData: due to incorrectness, we're deprecating `responseInsert` (this is not `responseInsert`, see below).
 
 ### Improvements
 
@@ -25,7 +26,8 @@ All notable changes to this project will be documented in this file.
 * Fastlane: ensure translations export can handle "empty" targets.
 * Scripts: fix Xcode warnings for build steps without input/output files.
 * Bump dependencies (Sentry to 8).
-* CoreData: ensure `requestInsert` imports objects on the context's thread. Note: because of limitations, we're deprecating `responseInsert`.
+* CoreData: ensure `requestInsert` imports objects on the context's thread.
+* Sourcery: fix code generation for `Self.ID` properties.
 
 ### Internal
 

--- a/Scripts/swiftlint.sh
+++ b/Scripts/swiftlint.sh
@@ -19,5 +19,5 @@ fi
 
 # Only execute during normal builds (not archives)
 if [ "$ACTION" != "install" ]; then
-  "$SWIFTLINT" lint --quiet
+  "$SWIFTLINT" lint --quiet --silence-deprecation-warnings
 fi

--- a/Sourcery/AutoViewModel.stencil
+++ b/Sourcery/AutoViewModel.stencil
@@ -19,7 +19,7 @@ import {{ module }}
 	{% set exists %}{% if viewModelType %}{% call propertyAlreadyExists var viewModelType %}{% endif %}{% endset %}
 	{% if not exists %}
 	{% set vmTypeName %}{% call viewModelFor var.type %}{% endset %}
-	var {{ var.name }}: {% if vmTypeName %}{{ vmTypeName }}{% if var.typeName.isOptional %}?{% endif %}{% else %}{{ var.typeName }}{% endif %} {
+	var {{ var.name }}: {% call typeNameFor var vmTypeName modelType %} {
 		{% if vmTypeName %}
 		return vm(data.{{ var.name }})
 		{% else %}
@@ -53,6 +53,16 @@ import {{ module }}
 			{% endif %}
 		{% endfor %}
 	{% endif %}
+{% endfilter %}{% endmacro %}
+{% macro typeNameFor var vmTypeName modelType %}{% filter removeNewlines:"all" %}
+	{% if vmTypeName %}
+		{{ vmTypeName }}
+	{% elif var.typeName.unwrappedTypeName|hasPrefix:'Self.' %}
+		{{ modelType.globalName }}.{{ var.typeName.unwrappedTypeName|replace:'Self.','' }}
+	{% else %}
+		{{ var.typeName.unwrappedTypeName }}
+	{% endif %}
+	{% if var.typeName.isOptional %}?{% endif %}
 {% endfilter %}{% endmacro %}
 
 // swiftlint:disable all


### PR DESCRIPTION
- Try to avoid Swift confusion with ViewModel generated properties, when using `Self.something` in a Model.
- Silence swiftlint script warnings