### PR TITLE
Bump Sentry to > 8.40

### DIFF
--- a/AppwiseCore.podspec
+++ b/AppwiseCore.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
 		ss.dependency 'AppwiseCore/Common'
 		ss.dependency 'Alamofire', '> 5.2'
 		ss.dependency 'CocoaLumberjack/Swift', '~> 3.6'
-		ss.dependency 'Sentry', '~> 8.0'
+		ss.dependency 'Sentry', '~> 8.40'
 		ss.dependency 'Then', '~> 3.0'
 	end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Main](https://github.com/appwise-labs/AppwiseCore)
 
+### Bug Fixes
+
+* Update Sentry to 8.40 to be make AppwiseCore compatible with Xcode 16.
+
 ## [2.1.0](https://github.com/appwise-labs/AppwiseCore/releases/tag/2.1.0)
 
 ### Deprecations


### PR DESCRIPTION
Projects depending on AppwiseCore do not build with the latest Xcode (16.0). Sentry is updated to resolve this issue.